### PR TITLE
codeship.io changed to codeship.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ First just deploy a free instance of the app on heroku using the button then jus
 1. Add a `Pull Request POST` hook in Bitbucket for `Create / Edit / Merge / Decline` that points to your instance of this app. The URL should look something like this:
 	- `https://<BITBUCKET_USERNAME>:<BITBUCKET_PASSWORD>@<YOUR_APP_NAME_ON_HEROKU>.herokuapp.com/pull-request/<CODESHIP_PROJECT_UUID>/<CODESHIP_PROJECT_ID>`
 	- Which would look something like this: `https://username:password@bitbucket-codeship-status-example.herokuapp.com/pull-request/ee1399cc-b740-43da-812f-d17901f9efa7/52132`
-1. Now whenever a pull request is created, it should (almost instantly) get updated to have the [Codeship Status Badge](https://www.codeship.io/documentation/faq/codeship-badge/) in the description.
+1. Now whenever a pull request is created, it should (almost instantly) get updated to have the [Codeship Status Badge](https://www.codeship.com/documentation/faq/codeship-badge/) in the description.
 
 # Running Locally
 

--- a/app.js
+++ b/app.js
@@ -48,7 +48,7 @@ module.exports = function () {
 		
 		// if it doesn't already have Codeship status at the start of the description, let's add it
 		if (pullRequest.description.indexOf('[ ![Codeship Status') !== 0) {
-			var widget = '[ ![Codeship Status for ' + pullRequest.source.repository.full_name + '](https://codeship.io/projects/' + req.params.codeshipProjectUuid + '/status?branch=' + pullRequest.source.branch.name + ')](https://codeship.io/projects/' + req.params.codeshipProjectId + ')';
+			var widget = '[ ![Codeship Status for ' + pullRequest.source.repository.full_name + '](https://codeship.com/projects/' + req.params.codeshipProjectUuid + '/status?branch=' + pullRequest.source.branch.name + ')](https://codeship.com/projects/' + req.params.codeshipProjectId + ')';
 			pullRequest.description = widget + '\r\n\r\n' + pullRequest.description;
 			
 			request({

--- a/test/pull-request-existing.json
+++ b/test/pull-request-existing.json
@@ -1,6 +1,6 @@
 {
 	"pullrequest": {
-		"description": "[ ![Codeship Status for chesleybrown/codeship-example](https://codeship.io/projects/b3416dba-b738-493b-ba33-6a6bed2948ed/status?branch=example-branch)](https://codeship.io/projects/433413) Description already has codeship status.",
+		"description": "[ ![Codeship Status for chesleybrown/codeship-example](https://codeship.com/projects/b3416dba-b738-493b-ba33-6a6bed2948ed/status?branch=example-branch)](https://codeship.com/projects/433413) Description already has codeship status.",
 		"links": {
 			"decline": {
 				"href": "https://api.bitbucket.org/2.0/repositories/evzijst/bitbucket2/pullrequests/24/decline"

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -129,7 +129,7 @@
 							<% } %>
 						</li>
 						<li>
-							<p>Now whenever a pull request is created, it should (almost instantly) get updated to have the <a href="https://www.codeship.io/documentation/faq/codeship-badge/">Codeship Status Badge</a> in the description.</p>
+							<p>Now whenever a pull request is created, it should (almost instantly) get updated to have the <a href="https://www.codeship.com/documentation/faq/codeship-badge/">Codeship Status Badge</a> in the description.</p>
 						</li>
 					</ol>
 				</div>


### PR DESCRIPTION
The SSL certs for codeship.io are currently invalid and the the official badge page for codeship is saying `.com` now and not `.io`.

So a good time to change.
